### PR TITLE
synchronize around calls to StreamObserver.onNext()

### DIFF
--- a/jgroups-36/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-36/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -98,7 +98,11 @@ public class UPGRADE extends Protocol {
                     if(msg.getSrc() == null)
                         msg.setSrc(local_addr);
                     Request req=Request.newBuilder().setMessage(jgroupsMessageToProtobufMessage(cluster, msg)).build();
-                    send_stream.onNext(req);
+                    synchronized (send_stream) {
+                        // Per javadoc, StreamObserver is not thread-safe and calls onNext()
+                        // must be handled by the application
+                        send_stream.onNext(req);
+                    }
                 }
                 return null;
             case Event.SET_LOCAL_ADDRESS:

--- a/jgroups-4/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-4/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -132,7 +132,11 @@ public class UPGRADE extends Protocol {
             if(msg.getSrc() == null)
                 msg.setSrc(local_addr);
             Request req=Request.newBuilder().setMessage(jgroupsMessageToProtobufMessage(cluster, msg)).build();
-            send_stream.onNext(req);
+            synchronized (send_stream) {
+                // Per javadoc, StreamObserver is not thread-safe and calls onNext()
+                // must be handled by the application
+                send_stream.onNext(req);
+            }
         }
         return null;
     }

--- a/jgroups-5/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-5/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -133,7 +133,11 @@ public class UPGRADE extends Protocol {
             Request req=null;
             try {
                 req=Request.newBuilder().setMessage(jgroupsMessageToProtobufMessage(cluster, msg)).build();
-                send_stream.onNext(req);
+                synchronized (send_stream) {
+                    // Per javadoc, StreamObserver is not thread-safe and calls onNext()
+                    // must be handled by the application
+                    send_stream.onNext(req);
+                }
             }
             catch(Exception e) {
                 log.error("%s: failed sending message: %s", local_addr, e);


### PR DESCRIPTION
add synchronize block around calls to StreamObserver.onNext() to be thread safe to resolve error: 'Invalid protobuf byte sequence' at the rolling upgrade server