### PR TITLE
add support for exclusion list from RequestCorrelator.MultiDestinationHeader

### DIFF
--- a/jgroups-36/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-36/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -292,7 +292,7 @@ public class UPGRADE extends Protocol {
 
             Address[] exclusions = mdhdr.exclusion_list;
             if (exclusions != null && exclusions.length > 0) {
-                rpcHeader.addAllExclusionList(Arrays.asList(exclusions).stream().map(UPGRADE::jgroupsAddressToProtobufAddress).collect(Collectors.toList()));
+                rpcHeader.addAllExclusionList(Arrays.stream(exclusions).map(UPGRADE::jgroupsAddressToProtobufAddress).collect(Collectors.toList()));
             }
         }
 

--- a/jgroups-36/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-36/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -18,7 +18,9 @@ import org.jgroups.upgrade_server.*;
 import org.jgroups.util.UUID;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -56,7 +58,7 @@ public class UPGRADE extends Protocol {
     protected ManagedChannel                            channel;
     protected UpgradeServiceGrpc.UpgradeServiceStub     asyncStub;
     protected StreamObserver<Request>                   send_stream; // for sending of messages and join requests
-    protected final Lock                                send_stream_lock=new ReentrantLock();
+    protected final Lock send_stream_lock = new ReentrantLock();
     protected static final short                        REQ_ID=ClassConfigurator.getProtocolId(RequestCorrelator.class);
 
 
@@ -86,8 +88,12 @@ public class UPGRADE extends Protocol {
     public void stop() {
         super.stop();
         channel.shutdown();
+        try {
+            channel.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
     }
-
 
     public Object down(Event evt) {
         switch(evt.type()) {
@@ -280,7 +286,17 @@ public class UPGRADE extends Protocol {
     }
 
     protected static RpcHeader jgroupsReqHeaderToProtobufRpcHeader(RequestCorrelator.Header hdr) {
-        return RpcHeader.newBuilder().setType(hdr.type).setRequestId(hdr.req_id).setCorrId(hdr.corrId).build();
+        RpcHeader.Builder rpcHeader = RpcHeader.newBuilder().setType(hdr.type).setRequestId(hdr.req_id).setCorrId(hdr.corrId);
+        if (hdr instanceof RequestCorrelator.MultiDestinationHeader) {
+            RequestCorrelator.MultiDestinationHeader mdhdr = (RequestCorrelator.MultiDestinationHeader) hdr;
+
+            Address[] exclusions = mdhdr.exclusion_list;
+            if (exclusions != null && exclusions.length > 0) {
+                rpcHeader.addAllExclusionList(Arrays.asList(exclusions).stream().map(UPGRADE::jgroupsAddressToProtobufAddress).collect(Collectors.toList()));
+            }
+        }
+
+        return rpcHeader.build();
     }
 
     protected static RequestCorrelator.Header protobufRpcHeaderToJGroupsReqHeader(RpcHeader hdr) {

--- a/jgroups-4/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-4/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -19,9 +19,11 @@ import org.jgroups.util.NameCache;
 import org.jgroups.util.UUID;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -89,6 +91,11 @@ public class UPGRADE extends Protocol {
     public void stop() {
         super.stop();
         channel.shutdown();
+        try {
+            channel.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
     }
 
 
@@ -291,7 +298,18 @@ public class UPGRADE extends Protocol {
     }
 
     protected static RpcHeader jgroupsReqHeaderToProtobufRpcHeader(RequestCorrelator.Header hdr) {
-        return RpcHeader.newBuilder().setType(hdr.type).setRequestId(hdr.req_id).setCorrId(hdr.corrId).build();
+        RpcHeader.Builder builder = RpcHeader.newBuilder().setType(hdr.type).setRequestId(hdr.req_id).setCorrId(hdr.corrId);
+
+        if (hdr instanceof RequestCorrelator.MultiDestinationHeader) {
+            RequestCorrelator.MultiDestinationHeader mdhdr = (RequestCorrelator.MultiDestinationHeader) hdr;
+
+            Address[] exclusions = mdhdr.exclusion_list;
+            if (exclusions != null && exclusions.length > 0) {
+                builder.addAllExclusionList(Arrays.stream(exclusions).map(UPGRADE::jgroupsAddressToProtobufAddress).collect(Collectors.toList()));
+            }
+        }
+
+        return builder.build();
     }
 
     protected static RequestCorrelator.Header protobufRpcHeaderToJGroupsReqHeader(RpcHeader hdr) {

--- a/jgroups-5/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-5/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -99,8 +100,12 @@ public class UPGRADE extends Protocol {
     public void stop() {
         super.stop();
         channel.shutdown();
+        try {
+            channel.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
     }
-
 
     public Object down(Event evt) {
         switch(evt.type()) {

--- a/jgroups-5/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
+++ b/jgroups-5/src/main/java/org/jgroups/protocols/upgrade/UPGRADE.java
@@ -23,6 +23,7 @@ import org.jgroups.util.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -366,7 +367,18 @@ public class UPGRADE extends Protocol {
     }
 
     protected static RpcHeader jgroupsReqHeaderToProtobufRpcHeader(RequestCorrelator.Header hdr) {
-        return RpcHeader.newBuilder().setType(hdr.type).setRequestId(hdr.req_id).setCorrId(hdr.corrId).build();
+        RpcHeader.Builder builder = RpcHeader.newBuilder().setType(hdr.type).setRequestId(hdr.req_id).setCorrId(hdr.corrId);
+
+        if (hdr instanceof RequestCorrelator.MultiDestinationHeader) {
+            RequestCorrelator.MultiDestinationHeader mdhdr = (RequestCorrelator.MultiDestinationHeader) hdr;
+
+            Address[] exclusions = mdhdr.exclusion_list;
+            if (exclusions != null && exclusions.length > 0) {
+                builder.addAllExclusionList(Arrays.stream(exclusions).map(UPGRADE::jgroupsAddressToProtobufAddress).collect(Collectors.toList()));
+            }
+        }
+
+        return builder.build();
     }
 
     protected static RequestCorrelator.Header protobufRpcHeaderToJGroupsReqHeader(RpcHeader hdr) {

--- a/upgrade-server/src/main/java/org/jgroups/upgrade_server/UpgradeService.java
+++ b/upgrade-server/src/main/java/org/jgroups/upgrade_server/UpgradeService.java
@@ -179,7 +179,7 @@ public class UpgradeService extends UpgradeServiceGrpc.UpgradeServiceImplBase {
         lock.lock();
         try {
             if(!map.isEmpty()) {
-                System.out.printf("-- relaying msg to %d members for cluster %s\n", map.size(), msg.getClusterName());
+                // System.out.printf("-- relaying msg to %d members for cluster %s\n", map.size(), msg.getClusterName());
                 Response response=Response.newBuilder().setMessage(msg).build();
 
                 // need to honor the exclusion list in the header if present


### PR DESCRIPTION
Copies the exclusion_list from the MultiDestinationHeader to the protobuf RpcHeader exclusion_list property and update the UpgradeService to support relay only to those nodes not in the exclusion_list.