### PR TITLE
Better name for the maven modules

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,15 +4,15 @@
 
    <parent>
       <groupId>org.jgroups.rolling-upgrades</groupId>
-      <artifactId>parent</artifactId>
+      <artifactId>jgroups-upgrade-parent</artifactId>
       <version>1.1.1.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>common</artifactId>
+   <artifactId>jgroups-upgrade-commons</artifactId>
    <packaging>jar</packaging>
-   <name>common</name>
-   <description>Common functionality</description>
+   <name>JGroups Rolling Upgrade commons</name>
+   <description>JGroups Rolling Upgrade commons</description>
 
    <dependencies>
       <dependency>
@@ -22,6 +22,4 @@
          <scope>test</scope>
       </dependency>
    </dependencies>
-
-
 </project>

--- a/jgroups-36/pom.xml
+++ b/jgroups-36/pom.xml
@@ -4,15 +4,15 @@
 
    <parent>
       <groupId>org.jgroups.rolling-upgrades</groupId>
-      <artifactId>parent</artifactId>
+      <artifactId>jgroups-upgrade-parent</artifactId>
       <version>1.1.1.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>jgroups-36</artifactId>
+   <artifactId>jgroups36-upgrade</artifactId>
    <packaging>jar</packaging>
-   <name>jgroups-36</name>
-   <description>Protocol for JGroups 3.6</description>
+   <name>JGroups 3.6.x UPGRADE protocol</name>
+   <description>JGroups 3.6.x UPGRADE protocol for Rolling Upgrades</description>
 
     <properties>
         <version.jgroups>3.6.15.Final</version.jgroups>
@@ -22,7 +22,7 @@
       
       <dependency>
          <groupId>org.jgroups.rolling-upgrades</groupId>
-         <artifactId>common</artifactId>
+         <artifactId>jgroups-upgrade-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
 

--- a/jgroups-4/pom.xml
+++ b/jgroups-4/pom.xml
@@ -4,15 +4,15 @@
 
    <parent>
       <groupId>org.jgroups.rolling-upgrades</groupId>
-      <artifactId>parent</artifactId>
+      <artifactId>jgroups-upgrade-parent</artifactId>
       <version>1.1.1.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>jgroups-4</artifactId>
+   <artifactId>jgroups4-upgrade</artifactId>
    <packaging>jar</packaging>
-   <name>jgroups-4</name>
-   <description>Protocol for JGroups 4.x</description>
+   <name>JGroups 4.x UPGRADE protocol</name>
+   <description>JGroups 4.x UPGRADE protocol for Rolling Upgrades</description>
 
    <properties>
       <version.jgroups>4.2.12.Final</version.jgroups>
@@ -22,7 +22,7 @@
       
       <dependency>
          <groupId>org.jgroups.rolling-upgrades</groupId>
-         <artifactId>common</artifactId>
+         <artifactId>jgroups-upgrade-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
 

--- a/jgroups-5/pom.xml
+++ b/jgroups-5/pom.xml
@@ -4,15 +4,15 @@
 
    <parent>
       <groupId>org.jgroups.rolling-upgrades</groupId>
-      <artifactId>parent</artifactId>
+      <artifactId>jgroups-upgrade-parent</artifactId>
       <version>1.1.1.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>jgroups-5</artifactId>
+   <artifactId>jgroups5-upgrade</artifactId>
    <packaging>jar</packaging>
-   <name>jgroups-5</name>
-   <description>Protocol for JGroups 5.x</description>
+   <name>JGroups 5.x UPGRADE protocol</name>
+   <description>JGroups 5.x UPGRADE protocol for Rolling Upgrades</description>
 
    <properties>
       <version.jgroups>5.1.9.Final</version.jgroups>
@@ -24,7 +24,7 @@
       
       <dependency>
          <groupId>org.jgroups.rolling-upgrades</groupId>
-         <artifactId>common</artifactId>
+         <artifactId>jgroups-upgrade-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jgroups.rolling-upgrades</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>jgroups-upgrade-parent</artifactId>
     <version>1.1.1.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>RollingUpgrades</name>
+    <name>JGroups Rolling Upgrades Parent</name>
     <url>https://github.com/jgroups-extras/RollingUpgrades</url>
 
     <modules>

--- a/upgrade-server/pom.xml
+++ b/upgrade-server/pom.xml
@@ -4,15 +4,15 @@
 
     <parent>
         <groupId>org.jgroups.rolling-upgrades</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>jgroups-upgrade-parent</artifactId>
         <version>1.1.1.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>upgrade-server</artifactId>
+    <artifactId>jgroups-upgrade-server</artifactId>
     <packaging>jar</packaging>
-    <name>UpgradeServer</name>
-    <description>UpgradeServer</description>
+    <name>JGroups Upgrade Server</name>
+    <description>JGroups Upgrade Server for Rolling Upgrades</description>
 
     <properties>
         <netty.tcnative.version>2.0.36.Final</netty.tcnative.version>
@@ -23,7 +23,7 @@
       
         <dependency>
             <groupId>org.jgroups.rolling-upgrades</groupId>
-            <artifactId>common</artifactId>
+            <artifactId>jgroups-upgrade-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
Closes #15

Names when compiling
```
[INFO] Reactor Summary for JGroups Rolling Upgrades Parent 1.1.1.Final-SNAPSHOT:
[INFO] 
[INFO] JGroups Rolling Upgrades Parent .................... SUCCESS [  0.748 s]
[INFO] JGroups Rolling Upgrade commons .................... SUCCESS [  2.329 s]
[INFO] JGroups Upgrade Server ............................. SUCCESS [  2.926 s]
[INFO] JGroups 3.6.x UPGRADE protocol ..................... SUCCESS [  0.502 s]
[INFO] JGroups 4.x UPGRADE protocol ....................... SUCCESS [  0.538 s]
[INFO] JGroups 5.x UPGRADE protocol ....................... SUCCESS [  0.559 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.518 s (Wall Clock)
[INFO] Finished at: 2021-11-25T12:05:45Z
```

Jar names
```
./common/target/jgroups-upgrade-commons-1.1.1.Final-SNAPSHOT.jar
./common/target/jgroups-upgrade-commons-1.1.1.Final-SNAPSHOT-sources.jar
./jgroups-36/target/jgroups36-upgrade-1.1.1.Final-SNAPSHOT.jar
./jgroups-36/target/jgroups36-upgrade-1.1.1.Final-SNAPSHOT-sources.jar
./upgrade-server/target/jgroups-upgrade-server-1.1.1.Final-SNAPSHOT-jar-with-dependencies.jar
./upgrade-server/target/jgroups-upgrade-server-1.1.1.Final-SNAPSHOT.jar
./upgrade-server/target/jgroups-upgrade-server-1.1.1.Final-SNAPSHOT-sources.jar
./jgroups-5/target/jgroups5-upgrade-1.1.1.Final-SNAPSHOT.jar
./jgroups-5/target/jgroups5-upgrade-1.1.1.Final-SNAPSHOT-sources.jar
./jgroups-4/target/jgroups4-upgrade-1.1.1.Final-SNAPSHOT.jar
./jgroups-4/target/jgroups4-upgrade-1.1.1.Final-SNAPSHOT-sources.jar
```